### PR TITLE
fix: Fix the require of 'Sequelize' to 'sequelize'

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -1,4 +1,4 @@
-var Sequelize = require('Sequelize');
+var Sequelize = require('sequelize');
 var sequelize = new Sequelize('trendwave', 'root', 'cake');
 var mysql = require('mysql');
 


### PR DESCRIPTION
'Sequelize' is not a package, but 'sequelize' is.
Not a problem on Macs, apparently (is npm or the fs to blame?), but is no bueno on a linux deploy server
